### PR TITLE
Remove rbenv in favor of ruby-build & add unprivileged user install

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Nicolas Goy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,50 @@
-Ruby
-====
+# Ruby
 
-Install ruby and rbenv.
+Compiles and install ruby using [ruby-build](https://github.com/rbenv/ruby-build)
+on RHEL based OS'es.
 
-Requirements
-------------
+## Security
 
-Tested with Ansible 1.6 or higher.
+### rbenv-build download location
 
-Role Variables
---------------
+Due some business requirements, some may be required to possess the installation
+files for rbenv-build. For that reason, you have an option to upload the
+`ruby-build` installation files yourself into your host and point it in your
+`rbenv_targz_url` var.
 
-- `ruby_install_path` - Path where ruby will be installed, default to `/srv`
-- `ruby_version` - Full version of the ruby to install (MRI) default to `2.2.2`
+### Compile and runs ruby as an unprivileged user
 
-Dependencies
-------------
+You may probably want to compile and run ruby as an unprivileged user, so the
+config by default assumes that you have an `deploy` user. If you want to disable
+it or change this user, just change the `use_unprivileged_user` and
+`unprivileged_user_name` vars.
+
+## Requirements
+
+Tested with Ansible 1.9 and 2.0.
+
+## Role Variables
+
+- `ruby_install_path` - Path where ruby will be installed, default to `$HOME/.rubies/ruby-2.2.4`
+- `ruby_version` - Full version of the ruby to install (MRI) default to `2.2.4`
+- `rbenv_targz_url` - Set it to the downloaded tar.gz from
+[ruby-build releases](https://github.com/rbenv/ruby-build/releases).
+- `use_unprivileged_user` - Sets whether you are _sudoing_ to a different user.
+- `unprivileged_user_name` - If the previous option is yes, then set this user here.
+
+## Dependencies
 
 none
 
-Example Playbook
-----------------
+## Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
-    - hosts: servers
-      roles:
-         - { role: kuon.ruby, ruby_install_path: '/opt' }
+```yaml
+- hosts: servers
+  roles:
+     - { role: kuon.ruby, ruby_install_path: '/opt/ruby' }
+```
+## License
 
-License
--------
-
-MIT
-
-
+MIT.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
-ruby_install_path: /srv
-ruby_version: 2.2.2
+rbenv_targz_url: https://github.com/rbenv/ruby-build/archive/v20160228.tar.gz
+ruby_version: 2.2.4
+ruby_install_path: ~/.rubies/ruby-{{ ruby_version }}
+use_unprivileged_user: yes
+unprivileged_user_name: deploy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,53 +1,59 @@
 ---
 - name: Install compiler and required packages
-  yum: name={{ item }}
+  become: yes
+  become_user: root
+  yum: name={{ item }} state=latest
   with_items:
   - make
   - gcc
-  - git
+  - gcc-c++
   - tar
   - bzip2
   - patch
-  - gcc-c++
-  - lzop
-  - postgresql-devel
   - openssl-devel
   - readline-devel
-  - readline-static
-  - readline
+  - libffi-devel
+  - libyaml-devel
+  - zlib-devel
+  - gdbm-devel
+  - ncurses-devel
 
+- name: Creates ruby-build directory
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  file: path=~/ruby-build state=directory force=yes
 
-- name: Checkout rbenv
-  command: git clone https://github.com/sstephenson/rbenv.git {{ ruby_install_path }}/rbenv
+- name: Downloads ruby-build
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  shell: "curl -Lk {{ rbenv_targz_url }} | tar xz --strip-components 1 --directory ~/ruby-build"
   args:
-    creates: '{{ ruby_install_path }}/rbenv/bin/rbenv'
+    creates: ~/ruby-build/bin/ruby-build
+    warn: no
 
-- name: Checkout ruby-build
-  command: git clone https://github.com/sstephenson/ruby-build.git {{ ruby_install_path }}/rbenv/plugins/ruby-build
+- name: Compiles Ruby
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  shell: "~/ruby-build/bin/ruby-build --verbose {{ ruby_version }} {{ ruby_install_path }}"
   args:
-    creates: '{{ ruby_install_path }}/rbenv/plugins/ruby-build'
+    creates: "{{ ruby_install_path }}/bin/ruby"
 
-- name: Install ruby
-  command: '{{ ruby_install_path }}/rbenv/bin/rbenv install {{ruby_version}}'
-  args:
-    creates: '{{ ruby_install_path }}/rbenv/versions/{{ ruby_version }}'
-  environment:
-    RBENV_ROOT: "{{ ruby_install_path }}/rbenv"
-    RBENV_VERSION: "{{ ruby_version }}"
+- name: Adds ruby bin dir to $PATH env var
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  lineinfile: dest=~/.bashrc line="export PATH={{ ruby_install_path }}/bin:$PATH"
 
-- name: Set default ruby
-  command: '{{ ruby_install_path }}/rbenv/bin/rbenv global {{ruby_version}}'
-  environment:
-    RBENV_ROOT: "{{ ruby_install_path }}/rbenv"
-    RBENV_VERSION: "{{ ruby_version }}"
+- name: Disable Gem docs installation by default
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  lineinfile: "dest=~/.gemrc create=yes line='gem: --no-document'"
 
-- name: Install base gems
-  command: '{{ ruby_install_path }}/rbenv/shims/gem install {{ item }} -N --no-user-install'
-  with_items:
-  - bundler
+- name: Update RubyGems
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  shell: "{{ ruby_install_path }}/bin/gem update --system"
 
-- name: Rehash gems
-  command: '{{ ruby_install_path }}/rbenv/bin/rbenv rehash'
-  environment:
-    RBENV_ROOT: "{{ ruby_install_path }}/rbenv"
-    RBENV_VERSION: "{{ ruby_version }}"
+- name: Install bundler
+  become: "{{ use_unprivileged_user }}"
+  become_user: "{{ unprivileged_user_name }}"
+  shell: "{{ ruby_install_path }}/bin/gem install bundler"

--- a/templates/rbenv.sh
+++ b/templates/rbenv.sh
@@ -1,3 +1,0 @@
-export PATH="{{ ruby_install_path }}/rbenv/bin:$PATH"
-export RBENV_ROOT="{{ ruby_install_path }}/rbenv"
-eval "$(rbenv init -)"


### PR DESCRIPTION
It was a unnecessary usage of `ruby-build` because we only want one Ruby installed.
Also, added the following features:
- Enabled usage of specific ruby-build release, so that you can roll your own or even host it;
- Enabled (by default) the compilation of ruby with unprivileged user - this can be changed, though;
- Added suggested packages to compile Ruby, according to ruby-build wiki;
- Update RubyGems and install Bundler;
- Disable docs when installing gems by default;

I added a License file as well, because the MIT licensing model requires it.
